### PR TITLE
Use padStart everywhere

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,28 +5,23 @@ export const format = (date: Date, exp: string): string => exp.replace(/{.*?}/g,
 		case '{yy}':
 			return `${date.getFullYear()}`.slice(-2);
 		case '{MM}': {
-			const month = date.getMonth() + 1;
-			return month < 10 ? `0${month}` : `${month}`;
+			return `${date.getMonth() + 1}`.padStart(2, '0');
 		}
 
 		case '{dd}': {
-			const day = date.getDate();
-			return day < 10 ? `0${day}` : `${day}`;
+			return `${date.getDate()}`.padStart(2, '0');
 		}
 
 		case '{HH}': {
-			const hours = date.getHours();
-			return hours < 10 ? `0${hours}` : `${hours}`;
+			return `${date.getHours()}`.padStart(2, '0');
 		}
 
 		case '{mm}': {
-			const minutes = date.getMinutes();
-			return minutes < 10 ? `0${minutes}` : `${minutes}`;
+			return `${date.getMinutes()}`.padStart(2, '0');
 		}
 
 		case '{ss}': {
-			const seconds = date.getSeconds();
-			return seconds < 10 ? `0${seconds}` : `${seconds}`;
+			return `${date.getSeconds()}`.padStart(2, '0');
 		}
 
 		case '{SSS}':


### PR DESCRIPTION
What about using padStart everywhere instead of using more complex ternaries ? 😀

edit: strange behavior from coveralls, I have 100% coverage when testing locally 🙈
![Screenshot 2020-08-24 at 19 18 13](https://user-images.githubusercontent.com/383297/91075619-a93e1380-e63e-11ea-84c8-f3f2d57dcf88.png)
