### PR TITLE
Remove intermediate variable to shave 12B off of `localeFormat()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 			"name": "localeFormat",
 			"path": "dist/index.esm.js",
 			"import": "{localeFormat}",
-			"limit": "177 B"
+			"limit": "165 B"
 		}
 	],
 	"dependencies": {}

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -10,7 +10,6 @@
  * localeFormat(new Date(2014, 1, 11), '{MMM}') //=> 'Jan'
  */
 export default (date: Date, exp: string, locale: string | string[] = 'en-US'): string => exp.replace(/{.*?}/g, key => {
-	const shortWeekday = new Intl.DateTimeFormat(locale, {weekday: 'short'}).format(date);
 	switch (key) {
 		case '{MMMMM}':
 			return new Intl.DateTimeFormat(locale, {month: 'narrow'}).format(date);
@@ -25,7 +24,7 @@ export default (date: Date, exp: string, locale: string | string[] = 'en-US'): s
 		case '{EEE}':
 		case '{EE}':
 		case '{E}':
-			return shortWeekday;
+			return new Intl.DateTimeFormat(locale, {weekday: 'short'}).format(date);
 		/* c8 ignore next 2 */
 		default:
 			return '';


### PR DESCRIPTION
177B → 165B. Should I also modify `package.json`?

As a bonus, this makes the file more consistent. (`shortWeekday` was the only intermediate variable.)