### PR TITLE
Change statements from `switch` to `if`

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,13 +93,13 @@
 			"name": "format",
 			"path": "dist/index.esm.js",
 			"import": "{format}",
-			"limit": "157 B"
+			"limit": "139 B"
 		},
 		{
 			"name": "localeFormat",
 			"path": "dist/index.esm.js",
 			"import": "{localeFormat}",
-			"limit": "165 B"
+			"limit": "154 B"
 		}
 	],
 	"dependencies": {}

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Light Date :alarm_clock:
 
-> Blazing fast & lightweight (157 bytes) date formatting for Node.js and the browser.
+> Blazing fast & lightweight (139 bytes) date formatting for Node.js and the browser.
 
 [![Build Status](https://github.com/xxczaki/light-date/workflows/CI/badge.svg)](https://github.com/xxczaki/light-date/actions?query=workflow%3ACI)
 [![Coverage Status](https://coveralls.io/repos/github/xxczaki/light-date/badge.svg?branch=master)](https://coveralls.io/github/xxczaki/light-date?branch=master)
@@ -13,7 +13,7 @@ This module aims to provide super fast and easy way to format dates, while also 
 
 ## Highlights
 
-* **Small.** 157 bytes (minified and gzipped). No dependencies. [Size Limit](https://github.com/ai/size-limit) controls the size.
+* **Small.** 139 bytes (minified and gzipped). No dependencies. [Size Limit](https://github.com/ai/size-limit) controls the size.
 * **Fast.** See the [benchmarks](#benchmarks).
 * **Compliant.** Follows [Unicode Technical Standard #35](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table).
 * **Well tested.** To make sure it handles various use cases correctly.

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,27 +9,40 @@
  * format(new Date(2014, 1, 11), '{yyyy}-{MM}-{dd}') //=> '2014-01-11'
  */
 export const format = (date: Date, exp: string): string => exp.replace(/{.*?}/g, key => {
-	switch (key) {
-		case '{yyyy}':
-			return `${date.getFullYear()}`;
-		case '{yy}':
-			return `${date.getFullYear()}`.slice(-2);
-		case '{MM}':
-			return `${(date.getMonth() + 1)}`.padStart(2, '0');
-		case '{dd}':
-			return `${date.getDate()}`.padStart(2, '0');
-		case '{HH}':
-			return `${date.getHours()}`.padStart(2, '0');
-		case '{mm}':
-			return `${date.getMinutes()}`.padStart(2, '0');
-		case '{ss}':
-			return `${date.getSeconds()}`.padStart(2, '0');
-		case '{SSS}':
-			return `${date.getMilliseconds()}`.padStart(3, '0');
-		/* c8 ignore next 2 */
-		default:
-			return '';
+	if (key === '{yyyy}') {
+		return `${date.getFullYear()}`;
 	}
+
+	if (key === '{yy}') {
+		return `${date.getFullYear()}`.slice(-2);
+	}
+
+	if (key === '{MM}') {
+		return `${(date.getMonth() + 1)}`.padStart(2, '0');
+	}
+
+	if (key === '{dd}') {
+		return `${date.getDate()}`.padStart(2, '0');
+	}
+
+	if (key === '{HH}') {
+		return `${date.getHours()}`.padStart(2, '0');
+	}
+
+	if (key === '{mm}') {
+		return `${date.getMinutes()}`.padStart(2, '0');
+	}
+
+	if (key === '{ss}') {
+		return `${date.getSeconds()}`.padStart(2, '0');
+	}
+
+	if (key === '{SSS}') {
+		return `${date.getMilliseconds()}`.padStart(3, '0');
+		/* c8 ignore next 3 */
+	}
+
+	return '';
 });
 
 /* c8 ignore next */

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -10,23 +10,30 @@
  * localeFormat(new Date(2014, 1, 11), '{MMM}') //=> 'Jan'
  */
 export default (date: Date, exp: string, locale: string | string[] = 'en-US'): string => exp.replace(/{.*?}/g, key => {
-	switch (key) {
-		case '{MMMMM}':
-			return new Intl.DateTimeFormat(locale, {month: 'narrow'}).format(date);
-		case '{MMMM}':
-			return new Intl.DateTimeFormat(locale, {month: 'long'}).format(date);
-		case '{MMM}':
-			return new Intl.DateTimeFormat(locale, {month: 'short'}).format(date);
-		case '{EEEEE}':
-			return new Intl.DateTimeFormat(locale, {weekday: 'narrow'}).format(date);
-		case '{EEEE}':
-			return new Intl.DateTimeFormat(locale, {weekday: 'long'}).format(date);
-		case '{EEE}':
-		case '{EE}':
-		case '{E}':
-			return new Intl.DateTimeFormat(locale, {weekday: 'short'}).format(date);
-		/* c8 ignore next 2 */
-		default:
-			return '';
+	if (key === '{MMMMM}') {
+		return new Intl.DateTimeFormat(locale, {month: 'narrow'}).format(date);
 	}
+
+	if (key === '{MMMM}') {
+		return new Intl.DateTimeFormat(locale, {month: 'long'}).format(date);
+	}
+
+	if (key === '{MMM}') {
+		return new Intl.DateTimeFormat(locale, {month: 'short'}).format(date);
+	}
+
+	if (key === '{EEEEE}') {
+		return new Intl.DateTimeFormat(locale, {weekday: 'narrow'}).format(date);
+	}
+
+	if (key === '{EEEE}') {
+		return new Intl.DateTimeFormat(locale, {weekday: 'long'}).format(date);
+	}
+
+	if (key === '{EEE}' || key === '{EE}' || key === '{E}') {
+		return new Intl.DateTimeFormat(locale, {weekday: 'short'}).format(date);
+		/* c8 ignore next 3 */
+	}
+
+	return '';
 });


### PR DESCRIPTION
Huge size savings. 😄

Performance stays about the same – maybe drops a little, but I don't know if 10 runs is enough to tell. In any case, the drop isn't likely too much.

Code readability also maybe drops a little, but hey, minus 18 bytes!

|                     | Size of `format`     | Size of `localeFormat` | Ops/sec (average of 10 runs)
| ------------------- | :------------------- | :--------------------- | :---------------------------
| **Current**         | 157 B                | 165 B                  | 1 247 244,9919
| **`switch` → `if`** | 139 B (- 18)         | 154 B (- 11)           | 1 214 782,9195

Btw, do you know why those `/* c8 ignore next 3 */` comments are needed? Or in other words, why does c8 fail to cover those lines? Edit: well, because the lines were not tested. 😅 I created #9 to add those missing tests.