### PR TITLE
Add escape mechanism

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 			"name": "format",
 			"path": "dist/index.esm.js",
 			"import": "{format}",
-			"limit": "174 B"
+			"limit": "180 B"
 		},
 		{
 			"name": "localeFormat",

--- a/package.json
+++ b/package.json
@@ -93,13 +93,13 @@
 			"name": "format",
 			"path": "dist/index.esm.js",
 			"import": "{format}",
-			"limit": "157 B"
+			"limit": "174 B"
 		},
 		{
 			"name": "localeFormat",
 			"path": "dist/index.esm.js",
 			"import": "{localeFormat}",
-			"limit": "165 B"
+			"limit": "188 B"
 		}
 	],
 	"dependencies": {}

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 			"name": "localeFormat",
 			"path": "dist/index.esm.js",
 			"import": "{localeFormat}",
-			"limit": "188 B"
+			"limit": "193 B"
 		}
 	],
 	"dependencies": {}

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Light Date :alarm_clock:
 
-> Blazing fast & lightweight (174 bytes) date formatting for Node.js and the browser.
+> Blazing fast & lightweight (180 bytes) date formatting for Node.js and the browser.
 
 [![Build Status](https://github.com/xxczaki/light-date/workflows/CI/badge.svg)](https://github.com/xxczaki/light-date/actions?query=workflow%3ACI)
 [![Coverage Status](https://coveralls.io/repos/github/xxczaki/light-date/badge.svg?branch=master)](https://coveralls.io/github/xxczaki/light-date?branch=master)

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Light Date :alarm_clock:
 
-> Blazing fast & lightweight (157 bytes) date formatting for Node.js and the browser.
+> Blazing fast & lightweight (174 bytes) date formatting for Node.js and the browser.
 
 [![Build Status](https://github.com/xxczaki/light-date/workflows/CI/badge.svg)](https://github.com/xxczaki/light-date/actions?query=workflow%3ACI)
 [![Coverage Status](https://coveralls.io/repos/github/xxczaki/light-date/badge.svg?branch=master)](https://coveralls.io/github/xxczaki/light-date?branch=master)
@@ -13,7 +13,7 @@ This module aims to provide super fast and easy way to format dates, while also 
 
 ## Highlights
 
-* **Small.** 157 bytes (minified and gzipped). No dependencies. [Size Limit](https://github.com/ai/size-limit) controls the size.
+* **Small.** 174 bytes (minified and gzipped). No dependencies. [Size Limit](https://github.com/ai/size-limit) controls the size.
 * **Fast.** See the [benchmarks](#benchmarks).
 * **Compliant.** Follows [Unicode Technical Standard #35](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table).
 * **Well tested.** To make sure it handles various use cases correctly.
@@ -133,6 +133,26 @@ dayjs                  x   281,183 ops/sec ±0.57% (96 runs sampled)
   const date = new Date();
 
   format(date, `Current date: ${localeFormat(date, '{MMMM}')} {dd}, {yyyy}`);
+  ```
+</details>
+
+<details>
+  <summary>How to escape pattern-reserved sequences?</summary>
+
+  Add a backslash before the opening curly bracket:
+
+  ```ts
+  import {format} from 'light-date';
+
+  format(new Date(), "I'm escaped: \\{yyyy} but I'm not: {yyyy}");
+  //=> "I'm espaced: {yyyy} but I'm not: 2020"
+  ```
+
+  To avoid having to escape backslashes, use `String.raw`:
+
+  ```ts
+  format(new Date(), String.raw`I'm escaped: \{yyyy} but I'm not: {yyyy}`;
+  //=> "I'm espaced: {yyyy} but I'm not: 2020"
   ```
 </details>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,7 @@
  * format(new Date(2014, 1, 11), '{yyyy}-{MM}-{dd}') //=> '2014-01-11'
  */
 export const format = (date: Date, exp: string): string => exp.replace(/\\?{.*?}/g, key => {
-	// Using `key.startsWith('\\')` would grow the minzipped size by a few bytes
-	// eslint-disable-next-line @typescript-eslint/prefer-string-starts-ends-with
-	if (key[0] === '\\') {
+	if (key.startsWith('\\')) {
 		return key.slice(1);
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,13 @@
  * @example
  * format(new Date(2014, 1, 11), '{yyyy}-{MM}-{dd}') //=> '2014-01-11'
  */
-export const format = (date: Date, exp: string): string => exp.replace(/{.*?}/g, key => {
+export const format = (date: Date, exp: string): string => exp.replace(/\\?{.*?}/g, key => {
+	// Using `key.startsWith('\\')` would grow the minzipped size by a few bytes
+	// eslint-disable-next-line @typescript-eslint/prefer-string-starts-ends-with
+	if (key[0] === '\\') {
+		return key.slice(1);
+	}
+
 	switch (key) {
 		case '{yyyy}':
 			return `${date.getFullYear()}`;

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -10,9 +10,7 @@
  * localeFormat(new Date(2014, 1, 11), '{MMM}') //=> 'Jan'
  */
 export default (date: Date, exp: string, locale: string | string[] = 'en-US'): string => exp.replace(/\\?{.*?}/g, key => {
-	// Using `key.startsWith('\\')` would grow the minzipped size by a few bytes
-	// eslint-disable-next-line @typescript-eslint/prefer-string-starts-ends-with
-	if (key[0] === '\\') {
+	if (key.startsWith('\\')) {
 		return key.slice(1);
 	}
 

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -9,7 +9,13 @@
  * @example
  * localeFormat(new Date(2014, 1, 11), '{MMM}') //=> 'Jan'
  */
-export default (date: Date, exp: string, locale: string | string[] = 'en-US'): string => exp.replace(/{.*?}/g, key => {
+export default (date: Date, exp: string, locale: string | string[] = 'en-US'): string => exp.replace(/\\?{.*?}/g, key => {
+	// Using `key.startsWith('\\')` would grow the minzipped size by a few bytes
+	// eslint-disable-next-line @typescript-eslint/prefer-string-starts-ends-with
+	if (key[0] === '\\') {
+		return key.slice(1);
+	}
+
 	switch (key) {
 		case '{MMMMM}':
 			return new Intl.DateTimeFormat(locale, {month: 'narrow'}).format(date);

--- a/test/format.ts
+++ b/test/format.ts
@@ -7,6 +7,8 @@ const bar = new Date('12/31/2003, 5:05:15 AM');
 test('general', t => {
 	t.is(format(foo, 'foo'), 'foo', 'does nothing if no match');
 	t.is(format(foo, 'HH'), 'HH', 'does nothing if no `{}` wrappers');
+	t.is(format(foo, '\\{HH}'), '{HH}', 'does nothing if `{` is escaped');
+	t.is(format(foo, String.raw`\{HH}`), '{HH}', 'does nothing if `{` is escaped with `String.raw`');
 	t.is(format(foo, '{yy}'), '20', 'returns partial year');
 	t.is(format(foo, '{yyyy}'), '2020', 'returns full year');
 	t.is(format(foo, '{MM}'), '05', 'returns month');

--- a/test/locale.ts
+++ b/test/locale.ts
@@ -6,6 +6,8 @@ const foo = new Date('8/1/2020, 4:30:09 PM');
 test('general', t => {
 	t.is(localeFormat(foo, 'foo'), 'foo', 'does nothing if no match');
 	t.is(localeFormat(foo, 'MMM'), 'MMM', 'does nothing if no `{}` wrappers');
+	t.is(localeFormat(foo, '\\{MMM}'), '{MMM}', 'does nothing if `{` is escaped');
+	t.is(localeFormat(foo, String.raw`\{MMM}`), '{MMM}', 'does nothing if `{` is escaped with `String.raw`');
 	t.is(localeFormat(foo, '{MMM}'), 'Aug', 'returns abbreviated month');
 	t.is(localeFormat(foo, '{MMMM}'), 'August', 'returns wide month');
 	t.is(localeFormat(foo, '{MMMMM}'), 'A', 'returns narrow month');


### PR DESCRIPTION
Closes #4.

Size increases by 17 bytes (`format`) and 23 bytes (`localeFormat`). Performance seems to be about the same.

|                            | Size of `format`     | Size of `localeFormat` | Ops/sec (average of 10 runs)
| -------------------------- | :------------------- | :--------------------- | :---------------------------
| **Current**                | 157 B                | 165 B                  | 1 247 244,9919000003
| **`key[0] === '\\'`**      | 174 B (+ 17)         | 188 B (+ 23)           | 1 249 209,8028
| **`key.startsWith('\\')`** | 180 B (+ 23)         | 193 B (+ 28)           | 1 264 293,1371

You might want to merge #7 first to save some bytes (see https://github.com/xxczaki/light-date/issues/4#issuecomment-719917787).