### PR TITLE
Add missing tests for the `default` switch cases

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,6 @@ export const format = (date: Date, exp: string): string => exp.replace(/{.*?}/g,
 			return `${date.getSeconds()}`.padStart(2, '0');
 		case '{SSS}':
 			return `${date.getMilliseconds()}`.padStart(3, '0');
-		/* c8 ignore next 2 */
 		default:
 			return '';
 	}

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -25,7 +25,6 @@ export default (date: Date, exp: string, locale: string | string[] = 'en-US'): s
 		case '{EE}':
 		case '{E}':
 			return new Intl.DateTimeFormat(locale, {weekday: 'short'}).format(date);
-		/* c8 ignore next 2 */
 		default:
 			return '';
 	}

--- a/test/format.ts
+++ b/test/format.ts
@@ -7,6 +7,8 @@ const bar = new Date('12/31/2003, 5:05:15 AM');
 test('general', t => {
 	t.is(format(foo, 'foo'), 'foo', 'does nothing if no match');
 	t.is(format(foo, 'HH'), 'HH', 'does nothing if no `{}` wrappers');
+	t.is(format(foo, '{foo}'), '', 'returns an empty string if invalid pattern');
+
 	t.is(format(foo, '{yy}'), '20', 'returns partial year');
 	t.is(format(foo, '{yyyy}'), '2020', 'returns full year');
 	t.is(format(foo, '{MM}'), '05', 'returns month');
@@ -28,4 +30,10 @@ test('formats', t => {
 	t.is(format(foo, '[{HH}:{mm}:{ss}]'), '[16:30:09]', 'returns formatted time string');
 	t.is(format(foo, 'The date is {MM}/{dd}/{yyyy}!'), 'The date is 05/01/2020!', 'returns formatted date string');
 	t.is(format(foo, 'Created on: [{yyyy}-{MM}-{dd} ~ {HH}:{mm}:{ss}.{SSS}]'), 'Created on: [2020-05-01 ~ 16:30:09.000]', 'kitchen sink');
+
+	t.is(
+		format(foo, 'Year is {yyyy} but {foo} is invalid'),
+		'Year is 2020 but  is invalid',
+		'returns formatted year but empty string for the invalid pattern'
+	);
 });

--- a/test/locale.ts
+++ b/test/locale.ts
@@ -6,6 +6,8 @@ const foo = new Date('8/1/2020, 4:30:09 PM');
 test('general', t => {
 	t.is(localeFormat(foo, 'foo'), 'foo', 'does nothing if no match');
 	t.is(localeFormat(foo, 'MMM'), 'MMM', 'does nothing if no `{}` wrappers');
+	t.is(localeFormat(foo, '{foo}'), '', 'returns an empty string if invalid pattern');
+
 	t.is(localeFormat(foo, '{MMM}'), 'Aug', 'returns abbreviated month');
 	t.is(localeFormat(foo, '{MMMM}'), 'August', 'returns wide month');
 	t.is(localeFormat(foo, '{MMMMM}'), 'A', 'returns narrow month');


### PR DESCRIPTION
I hadn't thought that an invalid pattern would be replaced with an empty string. I had somehow assumed that the invalid pattern would be returned as-is. So covering these cases in unit tests is IMO good. Furtherhore, without these tests, the coverage is not really 100%.

An alternative would be to `return key`, but that would grow the size of `format()` by a single byte.